### PR TITLE
Add analytic random-feature baselines ACIL and DS-AL

### DIFF
--- a/main_sldc.py
+++ b/main_sldc.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     parser.add_argument('--weight_decay', type=float, default=3e-5)
     parser.add_argument('--device', nargs='+', default=['0'])
     parser.add_argument('--lora_rank', type=int, default=4)
+    parser.add_argument('--num_used_layers', type=int, default=1)
     
     # Training parameters
     parser.add_argument('--sce_a', type=float, default=0.5)
@@ -79,6 +80,7 @@ if __name__ == '__main__':
     parser.add_argument('--kd_type', type=str, default='feat')
     parser.add_argument('--only_lora', default=True, action='store_true')
     parser.add_argument('--user', type=str, default='null', choices=['null'])
+    parser.add_argument('--num_workers', type=int, default=4)
 
     parser.add_argument('--use_linear_compensation', type=bool, default=False)
     parser.add_argument('--use_weak_nonlinear_compensation', type=bool, default=True)
@@ -91,6 +93,15 @@ if __name__ == '__main__':
     parser.add_argument('--use_auxiliary_data_enhancement', type=bool, default=True)
     parser.add_argument('--auxiliary_data_path', type=str, default="/data1/open_datasets/ImageNet-2012/train/")
     parser.add_argument('--auxiliary_data_size', type=int, default=1024)
+
+    # Analytic baselines (ACIL / DS-AL)
+    parser.add_argument('--random_feature_dim', type=int, default=8192)
+    parser.add_argument('--ridge_lambda', type=float, default=1e-3)
+    parser.add_argument('--rls_eps', type=float, default=1e-6)
+    parser.add_argument('--acil_activation', type=str, default='gelu')
+    parser.add_argument('--dsal_main_activation', type=str, default='gelu')
+    parser.add_argument('--dsal_comp_activation', type=str, default='tanh')
+    parser.add_argument('--dsal_fusion_weight', type=float, default=1.0)
 
     args = parser.parse_args()
     args = set_smart_defaults(args)  # Apply smart defaults

--- a/models/acil.py
+++ b/models/acil.py
@@ -1,0 +1,225 @@
+import logging
+import math
+from typing import Dict, List
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from models.base import BaseLearner
+from utils.inc_net import FinetuneIncrementalNet
+
+
+def _activation(name: str):
+    name = name.lower()
+    if name == "relu":
+        return torch.relu
+    if name == "gelu":
+        return torch.nn.functional.gelu
+    if name == "tanh":
+        return torch.tanh
+    if name == "mish":
+        return torch.nn.functional.mish
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+def _pad_columns(matrix: torch.Tensor, new_cols: int) -> torch.Tensor:
+    if new_cols <= 0:
+        return matrix
+    if matrix.numel() == 0:
+        return torch.zeros(
+            matrix.size(0),
+            new_cols,
+            device=matrix.device,
+            dtype=matrix.dtype,
+        )
+    padding = torch.zeros(
+        matrix.size(0), new_cols, device=matrix.device, dtype=matrix.dtype
+    )
+    return torch.cat([matrix, padding], dim=1)
+
+
+class ACILLearner(BaseLearner):
+    """Analytical Continual Incremental Learning (ACIL).
+
+    This learner freezes the ViT backbone and performs incremental ridge-regression
+    updates in a random feature space using the recursive least squares (RLS)
+    formulation described in the accompanying documentation.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.args = args
+        self._network = FinetuneIncrementalNet(
+            args, pretrained=True, num_used_layers=args.get("num_used_layers", 1)
+        )
+        self._network.to(self._device)
+        self._network.eval()
+        for param in self._network.convnet.parameters():
+            param.requires_grad = False
+
+        self._feature_dim = self._network.feature_dim
+        self._rf_dim = args.get("random_feature_dim", 8192)
+        self._ridge_lambda = args.get("ridge_lambda", 1e-3)
+        self._rls_eps = args.get("rls_eps", 1e-6)
+        activation_name = args.get("acil_activation", "gelu")
+        self._activation = _activation(activation_name)
+
+        self._weight_random = (
+            torch.randn(
+                self._feature_dim,
+                self._rf_dim,
+                device=self._device,
+                dtype=torch.float32,
+            )
+            / math.sqrt(self._feature_dim)
+        )
+        self._bias_random = torch.zeros(
+            self._rf_dim, device=self._device, dtype=torch.float32
+        )
+
+        identity = torch.eye(
+            self._rf_dim, device=self._device, dtype=torch.float32
+        )
+        self._R = identity / self._ridge_lambda
+        self._W = torch.zeros(
+            self._rf_dim, 0, device=self._device, dtype=torch.float32
+        )
+
+    # ------------------------------------------------------------------
+    # Core mathematics
+    # ------------------------------------------------------------------
+    def _compute_random_features(self, z: torch.Tensor) -> torch.Tensor:
+        projected = z @ self._weight_random + self._bias_random
+        return self._activation(projected)
+
+    def _rls_gain(self, X: torch.Tensor) -> torch.Tensor:
+        XR = X @ self._R
+        S = XR @ X.t()
+        batch_eye = torch.eye(
+            S.size(0), device=S.device, dtype=S.dtype
+        )
+        S = S + batch_eye + self._rls_eps * batch_eye
+        gain_t = torch.linalg.solve(S.transpose(-1, -2), XR)
+        return gain_t.transpose(0, 1)
+
+    def _rls_update(self, X: torch.Tensor, Y: torch.Tensor) -> None:
+        W_prev = _pad_columns(self._W, Y.size(1) - self._W.size(1))
+        gain = self._rls_gain(X)
+        self._R = self._R - gain @ X @ self._R
+        residual = Y - X @ W_prev
+        self._W = W_prev + gain @ residual
+
+    # ------------------------------------------------------------------
+    # Data helpers
+    # ------------------------------------------------------------------
+    def _build_dataloader(self, dataset, batch_size: int, shuffle: bool) -> DataLoader:
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            num_workers=self.args.get("num_workers", 4),
+        )
+
+    def _extract_features(self, loader: DataLoader) -> Dict[str, torch.Tensor]:
+        self._network.eval()
+        feats: List[torch.Tensor] = []
+        labels: List[torch.Tensor] = []
+        with torch.no_grad():
+            for _, (_, inputs, targets) in enumerate(loader):
+                inputs = inputs.to(self._device, non_blocking=True)
+                features = self._network.convnet(inputs)["features"]
+                feats.append(features.cpu())
+                labels.append(targets)
+        features_all = torch.cat(feats, dim=0).to(self._device)
+        labels_all = torch.cat(labels, dim=0).to(self._device)
+        return {"features": features_all, "labels": labels_all}
+
+    def _one_hot(self, labels: torch.Tensor, total_classes: int) -> torch.Tensor:
+        one_hot = torch.zeros(
+            labels.size(0), total_classes, device=self._device, dtype=torch.float32
+        )
+        one_hot.scatter_(1, labels.view(-1, 1), 1.0)
+        return one_hot
+
+    # ------------------------------------------------------------------
+    # Incremental interface
+    # ------------------------------------------------------------------
+    def incremental_train(self, data_manager):
+        self._cur_task += 1
+        task_size = data_manager.get_task_size(self._cur_task)
+        self._total_classes = self._known_classes + task_size
+        self.topk = min(self._total_classes, 5)
+
+        train_dataset = data_manager.get_dataset(
+            np.arange(self._known_classes, self._total_classes),
+            source="train",
+            mode="train",
+            appendent=[],
+            with_raw=False,
+        )
+
+        self.train_loader = self._build_dataloader(
+            train_dataset, self.args.get("batch_size", 64), shuffle=False
+        )
+
+        batch_data = self._extract_features(self.train_loader)
+        features = batch_data["features"]
+        labels = batch_data["labels"]
+
+        X_k = self._compute_random_features(features)
+        Y_k = self._one_hot(labels, self._total_classes)
+        self._rls_update(X_k, Y_k)
+
+        self._known_classes = self._total_classes
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+    def _forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            features = self._network.convnet(inputs)["features"]
+        X = self._compute_random_features(features)
+        return X @ self._W
+
+    def eval_task(self):
+        correct = 0
+        total = 0
+        self._network.eval()
+        with torch.no_grad():
+            for _, (_, inputs, targets) in enumerate(self.test_loader):
+                inputs = inputs.to(self._device, non_blocking=True)
+                targets = targets.to(self._device, non_blocking=True)
+                logits = self._forward(inputs)
+                preds = torch.argmax(logits, dim=1)
+                correct += (preds == targets).sum().item()
+                total += targets.size(0)
+
+        accuracy = 100.0 * correct / max(total, 1)
+        logging.info(
+            "Task %d | ACIL Accuracy: %.2f%%",
+            self._cur_task,
+            accuracy,
+        )
+        return {"acil": round(accuracy, 2)}
+
+    def loop(self, data_manager):
+        final_results = {"acil": []}
+        for task in range(data_manager.nb_tasks):
+            self.incremental_train(data_manager)
+
+            test_dataset = data_manager.get_dataset(
+                np.arange(0, self._total_classes), source="test", mode="test"
+            )
+            self.test_loader = self._build_dataloader(
+                test_dataset, self.args.get("batch_size", 64), shuffle=False
+            )
+
+            task_results = self.eval_task()
+            for key, value in task_results.items():
+                final_results.setdefault(key, [])
+                final_results[key].append(value)
+
+            super().after_task()
+
+        return final_results

--- a/models/dsal.py
+++ b/models/dsal.py
@@ -1,0 +1,271 @@
+import logging
+import math
+from typing import Dict, List
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from models.base import BaseLearner
+from utils.inc_net import FinetuneIncrementalNet
+
+
+def _activation(name: str):
+    name = name.lower()
+    if name == "relu":
+        return torch.relu
+    if name == "gelu":
+        return torch.nn.functional.gelu
+    if name == "tanh":
+        return torch.tanh
+    if name == "mish":
+        return torch.nn.functional.mish
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+def _pad_columns(matrix: torch.Tensor, new_cols: int) -> torch.Tensor:
+    if new_cols <= 0:
+        return matrix
+    if matrix.numel() == 0:
+        return torch.zeros(
+            matrix.size(0), new_cols, device=matrix.device, dtype=matrix.dtype
+        )
+    padding = torch.zeros(
+        matrix.size(0), new_cols, device=matrix.device, dtype=matrix.dtype
+    )
+    return torch.cat([matrix, padding], dim=1)
+
+
+class DSALLearner(BaseLearner):
+    """Dual-Stream Analytic Learner (DS-AL).
+
+    Extends ACIL with a compensation stream that fits residuals for the new
+    classes using a different activation function.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.args = args
+        self._network = FinetuneIncrementalNet(
+            args, pretrained=True, num_used_layers=args.get("num_used_layers", 1)
+        )
+        self._network.to(self._device)
+        self._network.eval()
+        for param in self._network.convnet.parameters():
+            param.requires_grad = False
+
+        self._feature_dim = self._network.feature_dim
+        self._rf_dim = args.get("random_feature_dim", 8192)
+        self._ridge_lambda = args.get("ridge_lambda", 1e-3)
+        self._rls_eps = args.get("rls_eps", 1e-6)
+        self._fusion_weight = args.get("dsal_fusion_weight", 1.0)
+
+        activation_main = args.get("dsal_main_activation", args.get("acil_activation", "gelu"))
+        activation_comp = args.get("dsal_comp_activation", "tanh")
+        self._activation_main = _activation(activation_main)
+        self._activation_comp = _activation(activation_comp)
+
+        self._weight_random = (
+            torch.randn(
+                self._feature_dim,
+                self._rf_dim,
+                device=self._device,
+                dtype=torch.float32,
+            )
+            / math.sqrt(self._feature_dim)
+        )
+        self._bias_random = torch.zeros(
+            self._rf_dim, device=self._device, dtype=torch.float32
+        )
+
+        identity = torch.eye(
+            self._rf_dim, device=self._device, dtype=torch.float32
+        )
+        self._R_main = identity / self._ridge_lambda
+        self._R_comp = identity.clone() / self._ridge_lambda
+        self._W_main = torch.zeros(
+            self._rf_dim, 0, device=self._device, dtype=torch.float32
+        )
+        self._W_comp = torch.zeros(
+            self._rf_dim, 0, device=self._device, dtype=torch.float32
+        )
+
+    # ------------------------------------------------------------------
+    # Feature helpers
+    # ------------------------------------------------------------------
+    def _project(self, features: torch.Tensor, stream: str) -> torch.Tensor:
+        projected = features @ self._weight_random + self._bias_random
+        if stream == "main":
+            return self._activation_main(projected)
+        return self._activation_comp(projected)
+
+    def _build_dataloader(self, dataset, batch_size: int, shuffle: bool) -> DataLoader:
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            num_workers=self.args.get("num_workers", 4),
+        )
+
+    def _extract_features(self, loader: DataLoader) -> Dict[str, torch.Tensor]:
+        feats: List[torch.Tensor] = []
+        labels: List[torch.Tensor] = []
+        self._network.eval()
+        with torch.no_grad():
+            for _, (_, inputs, targets) in enumerate(loader):
+                inputs = inputs.to(self._device, non_blocking=True)
+                features = self._network.convnet(inputs)["features"]
+                feats.append(features.cpu())
+                labels.append(targets)
+        features_all = torch.cat(feats, dim=0).to(self._device)
+        labels_all = torch.cat(labels, dim=0).to(self._device)
+        return {"features": features_all, "labels": labels_all}
+
+    def _one_hot(self, labels: torch.Tensor, total_classes: int) -> torch.Tensor:
+        one_hot = torch.zeros(
+            labels.size(0), total_classes, device=self._device, dtype=torch.float32
+        )
+        one_hot.scatter_(1, labels.view(-1, 1), 1.0)
+        return one_hot
+
+    # ------------------------------------------------------------------
+    # Recursive least squares updates
+    # ------------------------------------------------------------------
+    def _compute_gain(self, X: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
+        XR = X @ R
+        S = XR @ X.t()
+        eye = torch.eye(S.size(0), device=S.device, dtype=S.dtype)
+        S = S + eye + self._rls_eps * eye
+        gain_t = torch.linalg.solve(S.transpose(-1, -2), XR)
+        return gain_t.transpose(0, 1)
+
+    def _update_main(self, X: torch.Tensor, Y: torch.Tensor) -> None:
+        W_prev = _pad_columns(self._W_main, Y.size(1) - self._W_main.size(1))
+        gain = self._compute_gain(X, self._R_main)
+        self._R_main = self._R_main - gain @ X @ self._R_main
+        residual = Y - X @ W_prev
+        self._W_main = W_prev + gain @ residual
+
+    def _update_compensation(
+        self, X: torch.Tensor, residual_new: torch.Tensor, new_class_count: int
+    ) -> None:
+        W_prev_full = _pad_columns(self._W_comp, new_class_count)
+        current_block = W_prev_full[:, -new_class_count:].clone()
+        gain = self._compute_gain(X, self._R_comp)
+        self._R_comp = self._R_comp - gain @ X @ self._R_comp
+        block_residual = residual_new - X @ current_block
+        updated_block = current_block + gain @ block_residual
+        W_prev_full[:, -new_class_count:] = updated_block
+        self._W_comp = W_prev_full
+
+    # ------------------------------------------------------------------
+    # Incremental routine
+    # ------------------------------------------------------------------
+    def incremental_train(self, data_manager):
+        self._cur_task += 1
+        task_size = data_manager.get_task_size(self._cur_task)
+        self._total_classes = self._known_classes + task_size
+        self.topk = min(self._total_classes, 5)
+
+        train_dataset = data_manager.get_dataset(
+            np.arange(self._known_classes, self._total_classes),
+            source="train",
+            mode="train",
+            appendent=[],
+            with_raw=False,
+        )
+        self.train_loader = self._build_dataloader(
+            train_dataset, self.args.get("batch_size", 64), shuffle=False
+        )
+
+        batch_data = self._extract_features(self.train_loader)
+        features = batch_data["features"]
+        labels = batch_data["labels"]
+
+        X_main = self._project(features, stream="main")
+        targets = self._one_hot(labels, self._total_classes)
+        self._update_main(X_main, targets)
+
+        with torch.no_grad():
+            main_logits = X_main @ self._W_main
+        residual_full = targets - main_logits
+        residual_new = residual_full[:, self._known_classes : self._total_classes]
+
+        X_comp = self._project(features, stream="comp")
+        self._update_compensation(X_comp, residual_new, task_size)
+
+        self._known_classes = self._total_classes
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+    def _forward_main(self, inputs: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            features = self._network.convnet(inputs)["features"]
+        X = self._project(features, stream="main")
+        return X @ self._W_main
+
+    def _forward_comp(self, inputs: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            features = self._network.convnet(inputs)["features"]
+        X = self._project(features, stream="comp")
+        return X @ self._W_comp
+
+    def eval_task(self):
+        correct_main = 0
+        correct_fused = 0
+        total = 0
+
+        with torch.no_grad():
+            for _, (_, inputs, targets) in enumerate(self.test_loader):
+                inputs = inputs.to(self._device, non_blocking=True)
+                targets = targets.to(self._device, non_blocking=True)
+
+                logits_main = self._forward_main(inputs)
+                logits_comp = self._forward_comp(inputs)
+                logits_fused = logits_main + self._fusion_weight * logits_comp
+
+                preds_main = torch.argmax(logits_main, dim=1)
+                preds_fused = torch.argmax(logits_fused, dim=1)
+
+                correct_main += (preds_main == targets).sum().item()
+                correct_fused += (preds_fused == targets).sum().item()
+                total += targets.size(0)
+
+        acc_main = 100.0 * correct_main / max(total, 1)
+        acc_fused = 100.0 * correct_fused / max(total, 1)
+        logging.info(
+            "Task %d | DS-AL Main: %.2f%% | DS-AL Fused: %.2f%%",
+            self._cur_task,
+            acc_main,
+            acc_fused,
+        )
+        return {
+            "dsal_main": round(acc_main, 2),
+            "dsal_fused": round(acc_fused, 2),
+        }
+
+    def loop(self, data_manager):
+        final_results: Dict[str, List[float]] = {
+            "dsal_main": [],
+            "dsal_fused": [],
+        }
+
+        for task in range(data_manager.nb_tasks):
+            self.incremental_train(data_manager)
+
+            test_dataset = data_manager.get_dataset(
+                np.arange(0, self._total_classes), source="test", mode="test"
+            )
+            self.test_loader = self._build_dataloader(
+                test_dataset, self.args.get("batch_size", 64), shuffle=False
+            )
+
+            task_results = self.eval_task()
+            for key, value in task_results.items():
+                final_results.setdefault(key, [])
+                final_results[key].append(value)
+
+            super().after_task()
+
+        return final_results

--- a/models/sldc.py
+++ b/models/sldc.py
@@ -408,5 +408,4 @@ class SubspaceLoRA(BaseLearner):
         return final_results
 
 
-        
-    
+SLDC = SubspaceLoRA

--- a/trainer.py
+++ b/trainer.py
@@ -14,16 +14,8 @@ def train(args):
     seed_list = copy.deepcopy(args['seed'])
     device = copy.deepcopy(args['device'])
     
-    # Initialize storage for all results
-    all_runs_results = {
-        'original_fc': [],
-        'linear_fc': [],
-        'weak_nonlinear_fc': [],
-        'mlp_fc': [],
-        'linear_fc_aux': [],
-        'weak_nonlinear_fc_aux': [],
-        'mlp_fc_aux': []
-    }
+    # Initialize storage for all results (dynamically populated per model)
+    all_runs_results = {}
     
     for run_id, seed in enumerate(seed_list):
         args['seed'] = seed
@@ -81,12 +73,18 @@ def train(args):
             
         results = train_single_run(args)
         
-        # Store results for all classifier types
-        for classifier in all_runs_results.keys():
+        # Append results for existing classifiers, filling missing entries with None
+        for classifier in list(all_runs_results.keys()):
             if classifier in results:
                 all_runs_results[classifier].append(results[classifier])
             else:
                 all_runs_results[classifier].append(None)
+
+        # Add new classifier keys introduced by this run
+        for classifier, values in results.items():
+            if classifier not in all_runs_results:
+                all_runs_results[classifier] = [None] * run_id
+                all_runs_results[classifier].append(values)
     
         # Calculate and save statistics
         stats = calculate_statistics(all_runs_results)
@@ -137,11 +135,11 @@ def calculate_statistics(all_runs_results):
     stats = {}
     
     for classifier, runs in all_runs_results.items():
-        if not runs or not runs[0]:
+        valid_runs = [run for run in runs if run is not None]
+        if not valid_runs:
             continue
-            
-        # Convert to numpy array for easier calculations
-        num_tasks = len(runs[0])
+
+        num_tasks = len(valid_runs[0])
         num_runs = len(runs)
         
         # Initialize arrays
@@ -151,6 +149,8 @@ def calculate_statistics(all_runs_results):
         for task_idx in range(num_tasks):
             task_values = []
             for run_idx in range(num_runs):
+                if runs[run_idx] is None:
+                    continue
                 if runs[run_idx][task_idx] is not None:
                     task_values.append(runs[run_idx][task_idx])
             

--- a/utils/factory.py
+++ b/utils/factory.py
@@ -1,8 +1,14 @@
-import torch
+from models.acil import ACILLearner
+from models.dsal import DSALLearner
 from models.sldc import SLDC
+
+
 def get_model(model_name, args):
     name = model_name.lower()
     if 'sldc' in name:
         return SLDC(args)
-    else:
-        assert 0
+    if 'acil' in name:
+        return ACILLearner(args)
+    if 'dsal' in name:
+        return DSALLearner(args)
+    raise ValueError(f'Unknown model name: {model_name}')


### PR DESCRIPTION
## Summary
- add an ACIL learner that freezes the backbone and performs recursive least-squares updates in a random feature space
- extend the analytic approach with a DS-AL dual-stream learner that fits residuals for new classes and fuses the outputs
- expose the new baselines through the CLI, model factory, and dynamic trainer bookkeeping

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e6312d2b34833296c47a5319731004