### PR TITLE
Add dedicated ACIL entrypoint and enable DSAL first-task adaptation

### DIFF
--- a/main_acil.py
+++ b/main_acil.py
@@ -2,13 +2,14 @@ import argparse
 from trainer import train
 from evaluator import test
 
-# In[]
+
 def main(args):
-    args = vars(args)  # Converting argparse Namespace to a dict.
+    args = vars(args)
     if args['test_only']:
         test(args)
     else:
         train(args)
+
 
 def set_smart_defaults(args):
     if args.smart_defaults:
@@ -16,85 +17,127 @@ def set_smart_defaults(args):
             args.init_cls = 20
             args.increment = 20
             args.epochs = 15
-
         elif args.dataset == 'imagenet-r':
             args.init_cls = 20
             args.increment = 20
             args.epochs = 10
-        
         elif args.dataset == 'cifar100_224':
             args.init_cls = 10
-            args.increment = 10     
+            args.increment = 10
             args.epochs = 5
-
         elif args.dataset == 'cub200_224':
             args.init_cls = 20
             args.increment = 20
             args.epochs = 15
     return args
-# In[]
-import os
-# os.environ["CUDA_VISIBLE_DEVICES"] = "4"
+
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='SLDC experiments unified management.')
-    
+    parser = argparse.ArgumentParser(
+        description='ACIL / DS-AL experiments unified management.'
+    )
+
     # Basic options
     parser.add_argument('--test_only', default=False, action='store_true')
-    parser.add_argument('--dataset', type=str, default='imagenet-r', choices=['imagenet-r', 'cifar100_224', 'cub200_224', 'cars196_224'], help='Dataset to use')
+    parser.add_argument(
+        '--dataset',
+        type=str,
+        default='imagenet-r',
+        choices=['imagenet-r', 'cifar100_224', 'cub200_224', 'cars196_224'],
+        help='Dataset to use',
+    )
     parser.add_argument('--smart_defaults', default=False, action='store_true')
-    parser.add_argument('--prefix', type=str, default="original")
-    
-    # Memory parameters  
+    parser.add_argument('--prefix', type=str, default='original')
+
+    # Memory parameters
     parser.add_argument('--memory_size', type=int, default=0)
     parser.add_argument('--memory_per_class', type=int, default=0)
     parser.add_argument('--fixed_memory', default=False, action='store_true')
     parser.add_argument('--shuffle', default=True, action='store_true')
-    
+
     # Class parameters
     parser.add_argument('--init_cls', type=int, default=20)
     parser.add_argument('--increment', type=int, default=20)
-    
+
     # Model parameters
-    parser.add_argument('--model_name', type=str, default='sldc')
-    parser.add_argument('--vit_type', type=str, default='vit-b-p16-mocov3', choices=['vit-b-p16-lora-mocov3', 'vit-b-p16-lora', 'vit-b-p16-lora-mae'])
-    parser.add_argument('--lora_type', type=str, default='basic_lora', choices=['full', 'basic_lora'])
+    parser.add_argument(
+        '--model_name', type=str, default='acil', choices=['acil', 'dsal']
+    )
+    parser.add_argument(
+        '--vit_type',
+        type=str,
+        default='vit-b-p16-mocov3',
+        choices=['vit-b-p16-lora-mocov3', 'vit-b-p16-lora', 'vit-b-p16-lora-mae'],
+    )
+    parser.add_argument(
+        '--lora_type', type=str, default='basic_lora', choices=['full', 'basic_lora']
+    )
     parser.add_argument('--weight_decay', type=float, default=3e-5)
     parser.add_argument('--device', nargs='+', default=['0'])
     parser.add_argument('--lora_rank', type=int, default=4)
     parser.add_argument('--num_used_layers', type=int, default=1)
-    
-    # Training parameters
+
+    # Training parameters (mainly for logging consistency)
     parser.add_argument('--sce_a', type=float, default=0.5)
     parser.add_argument('--sce_b', type=float, default=0.5)
     parser.add_argument('--seed', nargs='+', type=int, default=[1990, 1996, 1997])
     parser.add_argument('--epochs', type=int, default=1)
     parser.add_argument('--ca_epochs', type=int, default=5)
     parser.add_argument('--optimizer', type=str, default='adamw')
-    # parser.add_argument('--optimizer', type=str, default='sgd')
     parser.add_argument('--lrate', type=float, default=1e-4)
     parser.add_argument('--head_scale', type=float, default=10.0)
-    parser.add_argument('--batch_size', type=int, default=16)
+    parser.add_argument('--batch_size', type=int, default=64)
     parser.add_argument('--tune_classifier', default=True)
-    parser.add_argument('--gamma_norm', default=0.1, type=float)
+    parser.add_argument('--gamma_norm', type=float, default=0.1)
     parser.add_argument('--gamma_kd', type=float, default=1.0)
     parser.add_argument('--kd_type', type=str, default='feat')
     parser.add_argument('--only_lora', default=True, action='store_true')
     parser.add_argument('--user', type=str, default='null', choices=['null'])
     parser.add_argument('--num_workers', type=int, default=4)
-
-    parser.add_argument('--use_linear_compensation', type=bool, default=False)
-    parser.add_argument('--use_weak_nonlinear_compensation', type=bool, default=True)
-    parser.add_argument('--use_mlp_compensation', type=bool, default=False)
-    parser.add_argument('--gamma_1', type=float, default=1e-4)
-    # parser.add_argument('--gamma_2', type=float, default=0.5)
     parser.add_argument('--gamma_2', type=float, default=0.5)
     parser.add_argument('--alpha_t', type=float, default=1.0)
 
-    parser.add_argument('--use_auxiliary_data_enhancement', type=bool, default=True)
-    parser.add_argument('--auxiliary_data_path', type=str, default="/data1/open_datasets/ImageNet-2012/train/")
-    parser.add_argument('--auxiliary_data_size', type=int, default=1024)
+    # Analytic baselines (ACIL / DS-AL)
+    parser.add_argument('--random_feature_dim', type=int, default=8192)
+    parser.add_argument('--ridge_lambda', type=float, default=1e-3)
+    parser.add_argument('--rls_eps', type=float, default=1e-6)
+    parser.add_argument(
+        '--acil_activation',
+        type=str,
+        default='gelu',
+        choices=['relu', 'gelu', 'tanh', 'mish'],
+    )
+    parser.add_argument(
+        '--dsal_main_activation',
+        type=str,
+        default='relu',
+        choices=['relu', 'gelu', 'tanh', 'mish'],
+    )
+    parser.add_argument(
+        '--dsal_comp_activation',
+        type=str,
+        default='tanh',
+        choices=['relu', 'gelu', 'tanh', 'mish'],
+    )
+    parser.add_argument('--dsal_fusion_weight', type=float, default=1.0)
+
+    # First-section adaptation options
+    parser.add_argument(
+        '--first_section_adaptation',
+        dest='first_section_adaptation',
+        action='store_true',
+    )
+    parser.add_argument(
+        '--no_first_section_adaptation',
+        dest='first_section_adaptation',
+        action='store_false',
+    )
+    parser.set_defaults(first_section_adaptation=True)
+    parser.add_argument('--fsa_epochs', type=int, default=1)
+    parser.add_argument('--fsa_lr', type=float, default=1e-4)
+    parser.add_argument('--fsa_weight_decay', type=float, default=0.0)
+    parser.add_argument('--fsa_batch_size', type=int, default=64)
 
     args = parser.parse_args()
-    args = set_smart_defaults(args)  # Apply smart defaults
+    args = set_smart_defaults(args)
     main(args)

--- a/models/dsal.py
+++ b/models/dsal.py
@@ -90,6 +90,13 @@ class DSALLearner(BaseLearner):
             self._rf_dim, 0, device=self._device, dtype=torch.float32
         )
 
+        self._fsa_done = False
+        self._use_fsa = bool(args.get("first_section_adaptation", True))
+        self._fsa_epochs = int(args.get("fsa_epochs", 1))
+        self._fsa_lr = float(args.get("fsa_lr", 1e-4))
+        self._fsa_wd = float(args.get("fsa_weight_decay", 0.0))
+        self._fsa_bs = int(args.get("fsa_batch_size", 64))
+
     # ------------------------------------------------------------------
     # Feature helpers
     # ------------------------------------------------------------------
@@ -120,6 +127,80 @@ class DSALLearner(BaseLearner):
         features_all = torch.cat(feats, dim=0).to(self._device)
         labels_all = torch.cat(labels, dim=0).to(self._device)
         return {"features": features_all, "labels": labels_all}
+
+    def _first_section_adaptation(self, data_manager) -> None:
+        """Adapt the frozen ViT encoder using the first task before analytic training."""
+
+        try:
+            first_task_size = data_manager.get_task_size(0)
+        except Exception:
+            first_task_size = data_manager.get_task_size(1)
+
+        train_dataset = data_manager.get_dataset(
+            np.arange(0, first_task_size),
+            source="train",
+            mode="train",
+            appendent=[],
+            with_raw=False,
+        )
+
+        train_loader = self._build_dataloader(
+            train_dataset, batch_size=self._fsa_bs, shuffle=True
+        )
+
+        for param in self._network.convnet.parameters():
+            param.requires_grad = True
+        self._network.train()
+
+        classifier = torch.nn.Linear(self._feature_dim, first_task_size).to(
+            self._device
+        )
+        optimizer = torch.optim.AdamW(
+            list(self._network.convnet.parameters()) + list(classifier.parameters()),
+            lr=self._fsa_lr,
+            weight_decay=self._fsa_wd,
+        )
+        criterion = torch.nn.CrossEntropyLoss()
+
+        for epoch in range(self._fsa_epochs):
+            running_loss = 0.0
+            total = 0
+            correct = 0
+
+            for _, (_, inputs, targets) in enumerate(train_loader):
+                inputs = inputs.to(self._device, non_blocking=True)
+                targets = targets.to(self._device, non_blocking=True)
+
+                optimizer.zero_grad(set_to_none=True)
+                features = self._network.convnet(inputs)["features"]
+                logits = classifier(features)
+                loss = criterion(logits, targets)
+                loss.backward()
+                optimizer.step()
+
+                running_loss += loss.item() * targets.size(0)
+                with torch.no_grad():
+                    preds = torch.argmax(logits, dim=1)
+                    correct += (preds == targets).sum().item()
+                    total += targets.size(0)
+
+            logging.info(
+                "[FSA] epoch=%d | loss=%.4f | acc=%.2f%%",
+                epoch + 1,
+                running_loss / max(total, 1),
+                100.0 * correct / max(total, 1),
+            )
+
+        del classifier
+        torch.cuda.empty_cache()
+
+        for param in self._network.convnet.parameters():
+            param.requires_grad = False
+        self._network.eval()
+        self._fsa_done = True
+        logging.info(
+            "[FSA] first_section_adaptation completed; convnet re-frozen for DS-AL."
+        )
 
     def _one_hot(self, labels: torch.Tensor, total_classes: int) -> torch.Tensor:
         one_hot = torch.zeros(
@@ -250,6 +331,9 @@ class DSALLearner(BaseLearner):
             "dsal_main": [],
             "dsal_fused": [],
         }
+
+        if self._use_fsa and not self._fsa_done:
+            self._first_section_adaptation(data_manager)
 
         for task in range(data_manager.nb_tasks):
             self.incremental_train(data_manager)


### PR DESCRIPTION
## Summary
- split the command-line interface so `main_sldc.py` only exposes SLDC-specific options and add a new `main_acil.py` for ACIL/DS-AL
- extend the ACIL/DS-AL entrypoint with first-section adaptation knobs for consistency with the analytical learners
- teach the DS-AL learner to run the same optional first-task adaptation routine before incremental training

## Testing
- python -m compileall main_sldc.py main_acil.py models/dsal.py

------
https://chatgpt.com/codex/tasks/task_e_68e73926f4cc83328d3bf85025fc0d19